### PR TITLE
Store user state to localStorage and emit event when chat is complete

### DIFF
--- a/chat/chat.py
+++ b/chat/chat.py
@@ -204,6 +204,7 @@ class ChatXBlock(StudioEditableXBlockMixin, XBlock):
         steps = self._steps_as_dict
         first_step = steps[self._steps_as_list[0]["id"]] if steps else None
         return {
+            "block_id": self._get_block_id(),
             "bot_image_url": (
                 self._expand_static_url(self.bot_image_url)
                 if self.bot_image_url else self._default_bot_image_url()
@@ -239,6 +240,19 @@ class ChatXBlock(StudioEditableXBlockMixin, XBlock):
         current_user = User.objects.get(username=username)  # pylint: disable=no-member
         urls = get_profile_image_urls_for_user(current_user)
         return urls.get('large')
+
+    def _get_block_id(self):
+        """
+        Return unique ID of this block. Useful for HTML ID attributes.
+
+        Works both in LMS/Studio and workbench runtimes:
+        - In LMS/Studio, use the location.html_id method.
+        - In the workbench, use the usage_id.
+        """
+        if hasattr(self, 'location'):
+            return self.location.html_id()  # pylint: disable=no-member
+        else:
+            return unicode(self.scope_ids.usage_id)
 
     @XBlock.handler
     def get_user_state(self, request, suffix=""):

--- a/chat/chat.py
+++ b/chat/chat.py
@@ -32,7 +32,7 @@ from .default_data import NAME_PLACEHOLDER, TYPING_DELAY_PER_CHARACTER
 from .utils import _
 
 try:
-    from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user  # pylint: disable=import-error
+    from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
 except ImportError:
     # This helper is not necessary when running tests because the
     # ChatXBlock._user_image_url method is patched

--- a/chat/public/js/src/chat.js
+++ b/chat/public/js/src/chat.js
@@ -377,7 +377,13 @@ function ChatXBlock(runtime, element, init_data) {
         // Only set currentTime if the sound has finished loading, otherwise some versions of FF
         // throw an error (see bug https://bugzilla.mozilla.org/show_bug.cgi?id=1188887)
         if (sound.readyState === 4) {
-            sound.currentTime = 0;
+            // Some versions of FF may still throw InvalidStateError when trying to set currentTime
+            // in some cases, so wrap it in a try/catch.
+            try {
+                sound.currentTime = 0;
+            } catch (e) {
+                // ignore
+            }
         }
         sound.play();
         last_sound_played = sound;

--- a/chat/public/js/src/chat.js
+++ b/chat/public/js/src/chat.js
@@ -265,6 +265,45 @@ function ChatXBlock(runtime, element, init_data) {
     var last_sound_played;
 
     /**
+     * localStorageKey: returns a key under which state for this block instance
+     * is stored in localStorage.
+     */
+    var localStorageKey = function() {
+        return 'chat-xblock-' + init_data["block_id"];
+    };
+
+    /**
+     * getStateFromLocalStorage: returns state saved in local storage, or null if it does not exist.
+     */
+    var getStateFromLocalStorage = function() {
+        var key = localStorageKey();
+        var state = null;
+        try {
+            state = localStorage.getItem(key);
+        } catch (e) {
+            // Fetching state from local storage will fail if localStorage is not available,
+            // or if browser settings forbid access to localStorage.
+            // Return null in that case.
+            return null;
+        }
+        return JSON.parse(state);
+    };
+
+    /**
+     * saveStateToLocalStorage: stores state to local storage. Ignores errors.
+     */
+    var saveStateToLocalStorage = function(serialized_state) {
+        var key = localStorageKey();
+        try {
+            localStorage.setItem(key, serialized_state);
+        } catch (e) {
+            // Storing state to local storage will fail if localStorage is not available,
+            // or if browser settings forbid access to localStorage.
+            // There is nothing we can do about that, so just ignore the error.
+        }
+    };
+
+    /**
      * pause: delays execution with a timeout
      */
     var pause = function(timeout) {
@@ -296,7 +335,8 @@ function ChatXBlock(runtime, element, init_data) {
         $element.on('click', '.response-button', submitResponse);
         $element.on('click', '.message-body img', showImageOverlay);
         $element.on('click', '.image-overlay', closeImageOverlay);
-        var state = init_data["user_state"];
+        // Try to load state from local storage and fall back to init_data.
+        var state = getStateFromLocalStorage() || init_data["user_state"];
         state.current_step = initialStep(state);
         state = addBotMessages(state);
         state.scroll_delay = 0;
@@ -428,14 +468,20 @@ function ChatXBlock(runtime, element, init_data) {
     };
 
     /**
-     * sendStateToServer: submits the state asyncrhonously
+     * saveState: stores state to localStorage and sends it to the server.
      */
-    var sendStateToServer = function() {
-        // Submit state to backend
+    var saveState = function() {
+        var serialized_state = JSON.stringify({
+            messages: state.messages,
+            current_step: state.current_step
+        });
+        // Save to localStorage.
+        saveStateToLocalStorage(serialized_state);
+        // Submit state to backend.
         $.ajax({
             type: 'POST',
             url: runtime.handlerUrl(element, "submit_response"),
-            data: JSON.stringify(state)
+            data: serialized_state
         });
     };
 
@@ -465,7 +511,7 @@ function ChatXBlock(runtime, element, init_data) {
           .then(waitUserMessageAnimation)
           .then(addUserMessageToHistory(event))
           .then(waitUserMessageAnimation)
-          .then(sendStateToServer)
+          .then(saveState)
           .then(addNewBotMessages(state));
     };
 

--- a/chat/utils.py
+++ b/chat/utils.py
@@ -1,5 +1,6 @@
 """Chat XBlock - Utils"""
 
+
 def _(text):
     """
     Dummy `gettext` replacement to make string extraction tools

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,20 @@
+machine:
+  python:
+    version: 2.7.10
+dependencies:
+  override:
+    - "pip install -U pip wheel"
+    # Temporarily pin setuptools to a specific version.
+    # See commit message of https://github.com/open-craft/problem-builder/commit/51277a34fb426724616618c1afdb893ab2de4c6b for more info:
+    - "pip install setuptools==24.3.1"
+    - "pip install -r requirements.txt"
+    - "pip install -r requirements-test.txt"
+    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
+    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
+    - "pip install -e ."
+    - "mkdir var"
+test:
+  override:
+    - "pep8 chat --max-line-length=120"
+    - "pylint chat --disable=all --enable=function-redefined,undefined-variable,unused-import,unused-variable"
+    - "python run_tests.py"

--- a/tests/integration/test_chat.py
+++ b/tests/integration/test_chat.py
@@ -265,9 +265,6 @@ class TestChat(StudioEditableBaseTest):
         patcher.start()
         self.addCleanup(patcher.stop)
 
-    def wait_until_buttons_are_displayed(self):
-        self.wait_until_exists('div.buttons.entering')
-
     def wait_for_ajax(self, timeout=15):
         """
         Wait for jQuery to be loaded and for all ajax requests to finish.
@@ -278,6 +275,9 @@ class TestChat(StudioEditableBaseTest):
             return self.browser.execute_script("return typeof(jQuery)!='undefined' && jQuery.active==0")
 
         EmptyPromise(is_ajax_finished, "Finished waiting for ajax requests.", timeout=timeout).fulfill()
+
+    def wait_until_buttons_are_displayed(self):
+        self.wait_until_exists('div.buttons.entering')
 
     def click_button(self, text):
         xpath_selector = '//button[contains(text(), "{}")]'.format(text)

--- a/tests/integration/test_chat.py
+++ b/tests/integration/test_chat.py
@@ -268,7 +268,6 @@ class TestChat(StudioEditableBaseTest):
     def wait_until_buttons_are_displayed(self):
         self.wait_until_exists('div.buttons.entering')
 
-
     def wait_for_ajax(self, timeout=15):
         """
         Wait for jQuery to be loaded and for all ajax requests to finish.
@@ -383,8 +382,7 @@ class TestChat(StudioEditableBaseTest):
         ]
         self.assertEqual(button_labels, step_a_response_labels)
         # go to step b
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "a-to-b-1")]').click()
+        self.click_button('a-to-b-1')
         self.wait_until_buttons_are_displayed()
         step_b_response_labels = [u'b-to-d-1']
         button_labels = [
@@ -394,8 +392,7 @@ class TestChat(StudioEditableBaseTest):
         ]
         self.assertEqual(button_labels, step_b_response_labels)
         # go to step d
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "b-to-d-1")]').click()
+        self.click_button('b-to-d-1')
         self.wait_until_buttons_are_displayed()
         step_d_response_labels = [u'd-to-f-1', u'd-to-g-1']
         button_labels = [
@@ -405,8 +402,7 @@ class TestChat(StudioEditableBaseTest):
         ]
         self.assertEqual(button_labels, step_d_response_labels)
         # go to step f
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "d-to-f-1")]').click()
+        self.click_button('d-to-f-1')
         self.wait_until_buttons_are_displayed()
         step_f_response_labels = [u'f-to-h-1', u'f-to-i-1']
         button_labels = [
@@ -416,8 +412,7 @@ class TestChat(StudioEditableBaseTest):
         ]
         self.assertEqual(button_labels, step_f_response_labels)
         # go to step i
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "f-to-i-1")]').click()
+        self.click_button('f-to-i-1')
         self.wait_until_buttons_are_displayed()
         step_i_response_labels = [u'Finish']
         button_labels = [
@@ -453,21 +448,17 @@ class TestChat(StudioEditableBaseTest):
         # save initial bot message
         first_bot_message = self.element.find_element_by_css_selector(selector).text
         # select wrong answer and try again
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "3")]').click()
+        self.click_button('3')
         self.wait_until_buttons_are_displayed()
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "Yes please")]').click()
+        self.click_button('Yes please')
         # the second message displayed has to be different to the initial one
         self.wait_until_buttons_are_displayed()
         second_bot_message = self.element.find_element_by_css_selector(selector).text
         self.assertNotEqual(second_bot_message, first_bot_message)
         # select wrong answer and try again
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "3")]').click()
+        self.click_button('3')
         self.wait_until_buttons_are_displayed()
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "Yes please")]').click()
+        self.click_button('Yes please')
         self.wait_until_buttons_are_displayed()
         # the third message displayed has to be different to the other two
         third_bot_message = self.element.find_element_by_css_selector(selector).text
@@ -475,11 +466,9 @@ class TestChat(StudioEditableBaseTest):
         self.assertNotEqual(third_bot_message, second_bot_message)
         # select wrong answer and try again
         self.wait_until_buttons_are_displayed()
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "3")]').click()
+        self.click_button('3')
         self.wait_until_buttons_are_displayed()
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "Yes please")]').click()
+        self.click_button('Yes please')
         self.wait_until_buttons_are_displayed()
         # the forth message displayed has to be different to the other three
         forth_bot_message = self.element.find_element_by_css_selector(selector).text
@@ -488,11 +477,9 @@ class TestChat(StudioEditableBaseTest):
         self.assertNotEqual(forth_bot_message, third_bot_message)
         # I know, this test can be optimized... now the fifth
         self.wait_until_buttons_are_displayed()
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "3")]').click()
+        self.click_button('3')
         self.wait_until_buttons_are_displayed()
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "Yes please")]').click()
+        self.click_button('Yes please')
         self.wait_until_buttons_are_displayed()
         fifth_bot_message = self.element.find_element_by_css_selector(selector).text
         self.assertNotEqual(fifth_bot_message, first_bot_message)
@@ -521,8 +508,7 @@ class TestChat(StudioEditableBaseTest):
         ]
         self.assertEqual(button_labels, ["2", "3"])
         # click on 3
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "3")]').click()
+        self.click_button('3')
         bot_messages = ["Hmm, no, it's not 3. (It's less.) Would you like to try again?"]
         bot_message = self.element.find_elements_by_css_selector('.messages .message-body p')[-1].text
         self.assertIn(bot_message, bot_messages)
@@ -613,11 +599,9 @@ class TestChat(StudioEditableBaseTest):
         self.assertEqual(img.get_attribute('alt'), 'This is another image in localhost')
         # Select wrong answer and try again a few times
         for i in range(3):
-            self.element.find_element_by_xpath(
-                '//button[contains(text(), "3")]').click()
+            self.click_button('3')
             self.wait_until_buttons_are_displayed()
-            self.element.find_element_by_xpath(
-                '//button[contains(text(), "Yes please")]').click()
+            self.click_button('Yes please')
             self.wait_until_buttons_are_displayed()
         # We have seven bot messages displayed by now
         bot_messages = self.element.find_elements_by_css_selector(selector)
@@ -678,8 +662,7 @@ class TestChat(StudioEditableBaseTest):
         first_message_1_5 = bot_messages[4].text
         self.assertIn(first_message_1_5, ['message step1.5.a', 'message step1.5.b', 'message step1.5.c'])
         # Let's repeat step 1
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "go back to step1")]').click()
+        self.click_button('go back to step1')
         self.wait_until_buttons_are_displayed()
         # Since messages 1.3 and 1.5 have subitems in them they show different options the second time
         bot_messages = self.element.find_elements_by_css_selector(selector)
@@ -711,7 +694,7 @@ class TestChat(StudioEditableBaseTest):
         self.configure_block(yaml_good, avatar_border_color='#00ffff')
         self.element = self.go_to_view("student_view")
         # Select a response to get the user's avatar
-        self.element.find_element_by_xpath('//button[contains(text(), "3")]').click()
+        self.click_button('3')
         # Get the avatar images for the three messages
         images = self.element.find_elements_by_css_selector('.messages .message .avatar img')
         # The images have the border-color set
@@ -738,19 +721,16 @@ class TestChat(StudioEditableBaseTest):
         # The name placeholder is replaced with the user's full name
         self.assertEqual(bot_messages[-1].text, "Hello John, what is 1+1?")
         self.wait_until_buttons_are_displayed()
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "3")]').click()
+        self.click_button('3')
         bot_messages = self.element.find_elements_by_css_selector('.messages .message.bot')
         self.assertEqual(
             bot_messages[-1].text,
             "Hmm, no John, it's not 3. (It's less.) Would you like to try again?"
         )
         self.wait_until_buttons_are_displayed()
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "Yes please")]').click()
+        self.click_button('Yes please')
         self.wait_until_buttons_are_displayed()
-        self.element.find_element_by_xpath(
-            '//button[contains(text(), "2")]').click()
+        self.click_button('2')
         bot_messages = self.element.find_elements_by_css_selector('.messages .message.bot')
         self.assertEqual(bot_messages[-1].text, "Yep, that's correct! Good job John.")
 
@@ -760,7 +740,7 @@ class TestChat(StudioEditableBaseTest):
         # localStorage should be empty initially.
         self.assertEqual(self.browser.execute_script('return localStorage.length'), 0)
         # Select a response to trigger saving the state.
-        self.element.find_element_by_xpath('//button[contains(text(), "2")]').click()
+        self.click_button('2')
         # localStorage should now contain user state.
         self.assertEqual(self.browser.execute_script('return localStorage.length'), 1)
         key = self.browser.execute_script('return localStorage.key(0)')
@@ -782,7 +762,7 @@ class TestChat(StudioEditableBaseTest):
         # Before clicking the button, we should not see message from step2:
         self.assertFalse(is_step2_visible())
         # Select a response to trigger saving the state.
-        self.element.find_element_by_xpath('//button[contains(text(), "2")]').click()
+        self.click_button('2')
         # We should now see the message from step2.
         self.assertTrue(is_step2_visible())
         # Patch the _get_user_state method to return a blank state.


### PR DESCRIPTION
### Store user state to `localStorage`

User state (current step and message history) is now stored into browser's `localStorage` in addition to the server. State in `localStorage` always takes precedence over state on the server.

**Notes and concerns**:
- Syncing local and server state was explicitly out of scope of this task. Even though state on the server may be newer than local state, we keep using local state.
- When testing the block, using the staff debug tools in the LMS to clear user state is no longer enough, you also need to invoke `localStorage.clear()` in your JS console. We might implement a "reset" button at some later point, but that was out of scope of this ticket.
- When working on a chat problem in the Studio (modifying steps and parameters), the locally stored state may get out of sync - for example the `current_step` property stored in local storage no longer points to a valid step. This is not a new problem as it can happen with the server-stored user state as well, and dealing with that is out of scope here.

### Emit tracking event when chat is complete

There are two ways the chat can complete:

1. The user chooses a response that does not lead to another step. The way authors currently implement that in YAML steps is to simply point the response to a non-existing step.
2. The user chooses a response that leads to a step with bot message(s), but no further user response options.

We implemented a method in the python code to detect each of this possibilities and emit a tracking event when chat is complete.

### Testing instructions

Install xblock-chat in your devstack environment and add a Chat block to your course (you'll have to add `"chat"` to the list of advanced modules in the Studio).

**Testing localStorage**:

1. Add two Chat blocks two two separate units in the same Subsection of your course (this allows you to move between the blocks without reloading the page).
2. Go to the subsection in the LMS, viewing the first block.
3. Stop your LMS python process to simulate offline mode.
4. Select a response or two, then move to the next unit (without reloading the page).
5. Move back to the first unit and observe that your responses are preserved.
6. Invoke `localStorage.clear()` in your JS console, then move to the next unit, and back again.
7. Observe that after clearing local storage, your previous responses are no longer preserved.

**Testing the "complete" event**:

1. Add Chat block with default configuration to your course.
2. Tail the tracking log in your devstack, filtering xblock-chat events: `tail -f /edx/var/log/tracking/tracking.log | grep xblock.chat`
3. Answer "No, not right now". At this point no event should be emitted yet.
4. Chose the final "Bye" response.
5. You should now see a tracking event of `xblock.chat.complete` type. The event data should equal `{"final_step": "COMPLETE"}`.
6. Reset user state using staff debug tool and clear local storage (`localStorage.clear()`), then reload the page.
7. Interact with the bot, always choosing the first available response.
8. After first three responses, no event should be emitted yet.
9. On the final ("Would you like to learn how to use this XBlock?") step, choose the "Yes, please!" response. At this point the event should be emitted with event data `{"final_step": "6"}`.

---

**Reviewers**:
- [ ] @smarnach 