### PR TITLE
Support for multiple bot personas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,29 +5,7 @@ An XBlock that allows learners to chat with a bot, where the bot follows
 a script and the learner can choose among possible responses.
 
 Authors define the script as a set of "steps".
-
-The steps list can be defined as a YAML sequence of mappings whose key represents
-the step id and the value is a nested mapping with messages and optional responses.
-It's also possible to add an optional image (with alternative text) to the step.
-
-A valid YAML steps sequence looks like this:
-
-```yaml
-- step1:
-    messages: ["What is 1+1?", "What is the sum of 1 and 1?"]
-    image-url: http://localhost/sum.png
-    image-alt: Graphic representation of this sum
-    responses:
-        - 2: step2
-        - 3: step3
-- step2:
-    messages: Yep, that's correct! Good job.
-- step3:
-    messages: Hmm, no, it's not 3. (It's less.) Would you like to try again?
-    responses:
-        - Yes please: step1
-        - No thanks: null
-```
+See [YAML Configuration](#yaml-configuration) section for more info.
 
 
 Installation
@@ -41,6 +19,7 @@ root folder:
 $ pip install -r requirements.txt
 ```
 
+
 Enabling in Studio
 ------------------
 
@@ -52,6 +31,160 @@ Settings.
 2. Check for the `Advanced Module List` policy key, and add
    `"chat"` to the policy value list.
 3. Click the "Save changes" button.
+
+
+YAML Configuration
+------------------
+
+The steps list is defined as a YAML sequence of mappings whose key represents
+the step id and the value is a nested mapping with messages and optional responses.
+We usually use `step1`, `step2`, ... in our examples, but please note that step
+ids are arbitrary.
+
+Each response is a mapping of response text to the next step id.
+
+The chat is complete when the users reaches a step that has no responses,
+or when the user selects a response which links to a non-existent step id.
+
+A valid YAML steps sequence looks like this:
+
+```yaml
+- step1:
+    messages: What is the sum of 1 and 1?
+    responses:
+        - 2: step2
+        - 3: step3
+- step2:
+    messages: Yep, that's correct! Good job.
+- step3:
+    messages: Hmm, no, it's not 3. (It's less.) Would you like to try again?
+    responses:
+        - Yes please: step1
+        - No thanks: null
+```
+
+### Sequence of Bot Messages
+
+Each step can contain more than one bot messages. Multiple bot messages are displayed
+in succession.
+
+```yaml
+- step1:
+    messages:
+        - Let's do some math!
+        - We will start with simple sums first.
+        - What is the sum of 1 and 1?
+    responses:
+        - 2: step2
+        - 3: step3
+- ...
+```
+
+### Step without Bot Messages
+
+Steps that contain an empty message attribute are valid and will display user
+responses immediatelly without transferring control to the bot, for example:
+
+```yaml
+- step1:
+    messages: Hello, would you like to learn some math?
+    responses:
+        - Yes please: step2
+        - No thanks: null
+- step2:
+    messages: []
+    responses:
+        - Let's do addition first: step3
+        - Let's do multiplication first: step4
+- ...
+```
+
+### Images in Bot Messages
+
+It is possible to add an optional image (with alternative text) to a step.
+
+```yaml
+- step1:
+    messages: What is the sum of 1 and 1?
+    image-url: http://example.com/sum.png
+    image-alt: Graphic representation of this sum.
+    responses:
+        - 2: step2
+        - 3: step3
+- ...
+```
+
+### Bot Message Randomization
+
+If a step contains a nested list of messages, a single message from the nested
+list is picked randomly each time the step is displayed. If the same step is
+displayed multiple times, it will pick a different message each time.
+
+In the example below, the first time the first step is displayed, the bot will
+pick one of "What is the sum of 1 and 1?" and "What is 1+1?" at random. If the
+user gets it wrong the first time, and then answers "Yes please" to try again,
+the first step is displayed again, but this time the other message will be
+chosen. If the user gets it wrong again and goes back to step1 the third time,
+the message will be picked randomly again.
+
+```yaml
+- step1:
+    messages:
+        - ["What is the sum of 1 and 1?", "What is 1+1?"]
+    responses:
+        - 2: step2
+        - 3: step3
+- step2:
+    messages: Correct.
+- step3:
+    messages: Wrong. Would you like to try again?
+    responses:
+        - Yes please: step1
+        - No thanks: null
+```
+
+### Multiple Bot Personas
+
+A single bot persona interacts with the user by default, but you can define
+multiple bot personas with different profile images.
+
+In order to use multiple bot personas, you have to define profile images for
+each bot persona as described in
+[Multiple Bot Image Configuration](#multiple-bot-image-configuration).
+
+You can then specify which message belongs to which bot persona in YAML
+configuration:
+
+```yaml
+- step1:
+    messages:
+        - alice: Hello, my name is Alice!
+        - bob: And I am Bob.
+        - alice: We will help you learn about quantum entanglement.
+    responses:
+        - Great: step2
+- ...
+```
+
+
+Bot Profile Image URL Configuration
+-----------------------------------
+
+A default bot profile image is provided by this xblock, but you can use a
+different image by entering its URL in the "Bot profile image URL" field
+in the Studio. You can use an absolute URL or a relative reference to images
+uploaded in the Studio (for example `/static/myimage.png`).
+
+### Multiple Bot Image Configuration
+
+When using [multiple bot personas](#multiple-bot-personas), you have to define
+the images for each bot persona as a YAML mapping of bot ids to image URLs,
+for example:
+
+```yaml
+alice: /static/alice-profile-img.jpg
+bob: /static/bob-profile-image.jpg
+```
 
 
 Testing

--- a/chat/default_data.py
+++ b/chat/default_data.py
@@ -37,7 +37,7 @@ DEFAULT_DATA = """- 1:
     - It's all in the README!
 """
 
-BOT_ID = 'bot'
+DEFAULT_BOT_ID = 'bot'
 USER_ID = 'user'
 BOT_MESSAGE_ANIMATION_DELAY = 2500
 USER_MESSAGE_ANIMATION_DELAY = 1000


### PR DESCRIPTION
This patch implements ability for course authors to specify multiple bot avatar images and allow multiple bot personas to chat with the user at the same time (so that multiple bots with different avatars can join in the conversation and reply to the user).

**Testing instructions**:

1. Add a new Chat block in the Studio, keeping the default settings.
2. Verify that default settings work for you in the LMS and that you can see the default bot image.
3. Upload some images to the Studio (under Content -> Files & Uploads). Square shaped images look best for avatars, but any shape will work. Write down their relative URLs (they will look like `/static/myimage.jpg`).
4. Edit the chat block you added previously and set the "Bot profile image URL" field to the URL of one of the images you uploaded to Studio. Publish the changes.
5. In the LMS, observe that you see your image instead of the default bot image.
6. Go back to editing the block in the Studio. This time define a YAML mapping of custom bot IDs to image URLs, for example:
```yaml
bot-1: /static/myimage1.jpg
bot-2: /static/myimage2.jpg
```
7. Now change some of the bot messages in the YAML steps configuration and tag them with your bot IDs. For example:
```yaml
# Change this:
messages: Hello
# into this:
messages:
    - bot1: Hello
```
8. Verify that the messages you've tagged with custom bot IDs display with correct avatar images in the LMS. Messages that you left untagged should be using the default bot image.
9. Verify that absolute image URLs work correctly, too.

**Note**:

This xblock stores state into `localStorage` in addition to the server, so when you're testing these changes, you will find that the "Delete learner's state" button from "Staff Debug" tools doesn't reset the problem. To completely reset the problem, you should invoke `localStorage.clear()` in the JS console in addition to invoking "Delete learner's state" staff debug tool.

**Reviewers**:

- [ ] @bdero