### PR TITLE
Added client call to empty handler when chat is complete

### DIFF
--- a/chat/chat.py
+++ b/chat/chat.py
@@ -292,7 +292,7 @@ class ChatXBlock(StudioEditableXBlockMixin, XBlock):
     def _is_final_step(self, step):
         """Returns true if current step doesn't exist or has no responses (is final step)."""
         steps_dict = self._steps_as_dict
-        # Step with this ID does not exists, which means the chat is complete.
+        # Step with this ID does not exist, which means the chat is complete.
         if step not in steps_dict:
             return True
         # Step exists, but has no user responses available, which means this is the final step.
@@ -593,3 +593,10 @@ class ChatXBlock(StudioEditableXBlockMixin, XBlock):
             except ImportError:
                 pass
         return url
+
+    @XBlock.handler
+    def chat_complete(self, request, suffix=""):
+        """This is called from the front end when the learner has completed the chat."""
+        # Does nothing at the moment; this HTTP request is listened for by some mobile apps
+        # to trigger events after the chat is completed.
+        return webob.Response()

--- a/chat/public/js/src/chat.js
+++ b/chat/public/js/src/chat.js
@@ -488,6 +488,24 @@ function ChatXBlock(runtime, element, init_data) {
     };
 
     /**
+     * isFinalStep: returns true if current step doesn't exist or has no responses.
+       This is the JS equivalent of the _is_final_step method of the XBlock.
+     */
+    var isFinalStep = function(step) {
+        var steps_dict = init_data["steps"];
+        // Step with this ID does not exist, which means the chat is complete.
+        if (!(step in steps_dict)) {
+            return true;
+        }
+        // Step exists, but has no user responses available, which means this is the final step.
+        if (steps_dict[step].responses.length == 0) {
+            return true;
+        }
+        // Step exists and has responses for the user to choose from, so this is not the final step.
+        return false;
+    };
+
+    /**
      * saveState: stores state to localStorage and sends it to the server.
      */
     var saveState = function() {
@@ -503,6 +521,13 @@ function ChatXBlock(runtime, element, init_data) {
             url: runtime.handlerUrl(element, "submit_response"),
             data: serialized_state
         });
+        // If it's the final step ping the chat_complete handler
+        if (isFinalStep(state.current_step)) {
+            $.ajax({
+                type: 'GET',
+                url: runtime.handlerUrl(element, "chat_complete")
+            });
+        }
     };
 
     /**

--- a/tests/integration/test_chat.py
+++ b/tests/integration/test_chat.py
@@ -890,3 +890,25 @@ class TestChat(StudioEditableBaseTest):
         self.click_button('OK')
         self.wait_for_ajax()
         mock_publish.assert_called_with(ANY, 'xblock.chat.complete', {'final_step': '4'})
+
+    @patch('chat.chat.ChatXBlock.chat_complete')
+    def test_ping_handler_when_chat_is_complete_with_non_existing_step(self, mock_handler):
+        mock_handler.return_value = {}
+        self.configure_block(yaml_final_steps)
+        self.element = self.go_to_view('student_view')
+        self.click_button('Response that points to non-existing step')
+        self.assertFalse(mock_handler.called)
+        self.click_button('OK')
+        self.wait_for_ajax()
+        self.assertTrue(mock_handler.called)
+
+    @patch('chat.chat.ChatXBlock.chat_complete')
+    def test_ping_handler_when_chat_is_complete_with_step_without_responses(self, mock_handler):
+        mock_handler.return_value = {}
+        self.configure_block(yaml_final_steps)
+        self.element = self.go_to_view('student_view')
+        self.click_button('Response that points to existing step with no further responses')
+        self.assertFalse(mock_handler.called)
+        self.click_button('OK')
+        self.wait_for_ajax()
+        self.assertTrue(mock_handler.called)


### PR DESCRIPTION
This PR adds an Xblock.handler and calls it from the JS client code when the chat is complete.

**JIRA ticket**: [OC-2534](https://tasks.opencraft.com/browse/OC-2534)

**Testing instructions**:

1. Add a new Chat block in Studio with the default sample steps.
2. In the LMS navigate to the XBlock and answer "No, not right now" which will trigger the final step.
3. Before clicking the "Bye!" response button open the Network tab in the Chrome Developer Tools.
4. After clicking the "Bye!" response button the "chat_complete" handler call should be displayed in the tools.

**Note**:

This xblock stores state into `localStorage` in addition to the server, so when you're testing these changes, you will find that the "Delete learner's state" button from "Staff Debug" tools doesn't reset the problem. To completely reset the problem, you should invoke `localStorage.clear()` in the JS console in addition to invoking "Delete learner's state" staff debug tool.

**Reviewers**
- [x] @bdero