### PR TITLE
Ping complete handler on page reload if chat complete.

### DIFF
--- a/chat/public/js/src/chat.js
+++ b/chat/public/js/src/chat.js
@@ -348,7 +348,10 @@ function ChatXBlock(runtime, element, init_data) {
         state.image_dimensions = {};
         applyState(state);
         state.scroll_delay = init_data["scroll_delay"];
-        return state
+        // Some mobile apps expect the chat_complete handler to be invoked
+        // every time when loading the block if block is in complete state.
+        pingHandlerIfComplete(state);
+        return state;
     };
 
     /**
@@ -506,6 +509,18 @@ function ChatXBlock(runtime, element, init_data) {
     };
 
     /**
+    * Sends a GET request to the chat_complete handler if we are on final step.
+    */
+    var pingHandlerIfComplete = function(state) {
+        if (isFinalStep(state.current_step)) {
+            $.ajax({
+                type: 'GET',
+                url: runtime.handlerUrl(element, "chat_complete")
+            });
+        }
+    };
+
+    /**
      * saveState: stores state to localStorage and sends it to the server.
      */
     var saveState = function() {
@@ -522,12 +537,7 @@ function ChatXBlock(runtime, element, init_data) {
             data: serialized_state
         });
         // If it's the final step ping the chat_complete handler
-        if (isFinalStep(state.current_step)) {
-            $.ajax({
-                type: 'GET',
-                url: runtime.handlerUrl(element, "chat_complete")
-            });
-        }
+        pingHandlerIfComplete(state);
     };
 
     /**

--- a/tests/integration/test_chat.py
+++ b/tests/integration/test_chat.py
@@ -901,6 +901,12 @@ class TestChat(StudioEditableBaseTest):
         self.click_button('OK')
         self.wait_for_ajax()
         self.assertTrue(mock_handler.called)
+        # The handler should be called again if we reload the page.
+        mock_handler.reset_mock()
+        self.assertFalse(mock_handler.called)
+        self.element = self.go_to_view('student_view')
+        self.wait_for_ajax()
+        self.assertTrue(mock_handler.called)
 
     @patch('chat.chat.ChatXBlock.chat_complete')
     def test_ping_handler_when_chat_is_complete_with_step_without_responses(self, mock_handler):
@@ -910,5 +916,11 @@ class TestChat(StudioEditableBaseTest):
         self.click_button('Response that points to existing step with no further responses')
         self.assertFalse(mock_handler.called)
         self.click_button('OK')
+        self.wait_for_ajax()
+        self.assertTrue(mock_handler.called)
+        # The handler should be called again if we reload the page.
+        mock_handler.reset_mock()
+        self.assertFalse(mock_handler.called)
+        self.element = self.go_to_view("student_view")
         self.wait_for_ajax()
         self.assertTrue(mock_handler.called)


### PR DESCRIPTION
In addition to pinging the handler at the moment when the user completes the chat, we also want to ping the handler every time the user visits a chat block which is in completed state.

**Testing instructions**:

1. Add a new Chat block in Studio with the default sample steps.
1. In the LMS navigate to the XBlock with the network console opened.
1. Observe that the `chat_complete` URL is not invoked.
1. Answer "No, not right now", and on the next step chose the "Bye!" response, which will complete the chat.
1. After clicking the "Bye!" response button the `chat_complete` handler should be invoked.
1. Reload the page and observe that the `chat_complete` handler is invoked after page reload.
1. Use staff debug tools to delete learner state and invoke `localStorage.clear()` in the JS console to reset the state of the block.
1. Reload the page and observe that the `chat_complete` handler is NOT invoked after page reload.

**Note**:

This xblock stores state into `localStorage` in addition to the server, so when you're testing these changes, you will find that the "Delete learner's state" button from "Staff Debug" tools doesn't reset the problem. To completely reset the problem, you should invoke `localStorage.clear()` in the JS console in addition to invoking "Delete learner's state" staff debug tool.

**Reviewers**:

- [x] @itsjeyd 