### PR TITLE
Implement restart button

### DIFF
--- a/chat/chat.py
+++ b/chat/chat.py
@@ -20,7 +20,7 @@ from django.core.validators import URLValidator
 from django.http import Http404
 
 from xblock.core import XBlock
-from xblock.fields import List, Scope, String
+from xblock.fields import List, Scope, String, Boolean
 from xblock.fragment import Fragment
 from xblock.validation import ValidationMessage
 from xblockutils.resources import ResourceLoader
@@ -94,6 +94,12 @@ class ChatXBlock(StudioEditableXBlockMixin, XBlock):
         scope=Scope.content,
     )
 
+    enable_restart_button = Boolean(
+        display_name=_("Enable restart button"),
+        default=False,
+        scope=Scope.content,
+    )
+
     messages = List(
         help=_(
             "List of dictionaries representing the messages exchanged "
@@ -117,6 +123,7 @@ class ChatXBlock(StudioEditableXBlockMixin, XBlock):
         "steps",
         "bot_image_url",
         "avatar_border_color",
+        "enable_restart_button",
     )
 
     @XBlock.supports("multi_device")  # Mark as mobile-friendly
@@ -224,6 +231,7 @@ class ChatXBlock(StudioEditableXBlockMixin, XBlock):
             "buttons_leaving_transition_duration": BUTTONS_LEAVING_TRANSITION_DURATION,
             "scroll_delay": SCROLL_DELAY,
             "avatar_border_color": self.avatar_border_color or None,
+            "enable_restart_button": self.enable_restart_button,
             "typing_delay_per_character": TYPING_DELAY_PER_CHARACTER,
         }
 
@@ -311,6 +319,12 @@ class ChatXBlock(StudioEditableXBlockMixin, XBlock):
         if self._is_final_step(self.current_step):
             data = {'final_step': self.current_step}
             self.runtime.publish(self, 'xblock.chat.complete', data)
+
+    @XBlock.json_handler
+    def reset(self, data, suffix=''):
+        """Resets chat state"""
+        self.messages = []
+        self.current_step = None
 
     @XBlock.handler
     def serve_audio(self, request, wav_name):

--- a/chat/public/css/chat.css
+++ b/chat/public/css/chat.css
@@ -158,12 +158,39 @@ body.view-in-course .course-wrapper.chromeless {
     color: #fff;
     border: none;
     box-shadow: none;
-    border-radius: 0;
     padding: 10px;
     font-weight: normal;
     text-shadow: none;
     outline: 0;
     border-radius: 10px;
+}
+
+.chat-block .actions {
+    text-align: right;
+    margin-top: 20px;
+}
+
+.chat-block .actions:empty {
+    margin-top: 0;
+}
+
+.chat-block .actions button,
+.chat-block .actions button:hover,
+.chat-block .actions button:active,
+.chat-block .actions button:focus {
+    color: #0075b4;
+    background: none;
+    border: none;
+    box-shadow: none;
+    font-family: Arial;
+    font-weight: normal;
+    font-size: 13px;
+}
+
+.chat-block .actions .restart-button::before {
+    content: "\f021";
+    font-family: FontAwesome;
+    padding-right: 5px;
 }
 
 .chat-block .image-overlay {


### PR DESCRIPTION
This implements the restart button, which is disabled by default. You can enable it in the Studio by setting the "Enable reset button" to `True` in the xblock edit dialog.

![screen shot 2017-05-18 at 10 37 23](https://cloud.githubusercontent.com/assets/32585/26193581/080ceb3e-3bb6-11e7-9465-feeead5d8678.png)

**Testing Instructions**:

1. Checkout this branch.
1. Add a chat block to your course and verify that the reset button is not visible by default.
1. In the xblock edit dialog, set the "Enable restart button" field to `True`, and publish the unit.
1. Reload the page in the LMS and observe that the "Restart" button is now visible at the bottom.
1. Interact with the bot by sending some responses.
1. As a sanity check, verify that the state of the chat gets persisted - if you reload the page, you should still see your responses.
1. Click the reset button. Verify that the chat resets to the initial state.
1. Reload the page. Verify that the chat is still in initial state.

**Author notes and concerns**:

I haven't been able to build the edX iOS app since I upgraded Xcode. There's [a branch in the edx-app-ios repository](https://github.com/edx/edx-app-ios/pull/919) that's supposed to provide support for Xcode 8.3, however it still doesn't work for me.
The android app does not build for me either, so I was not able to check this change in any mobile apps.

**Reviewers**:

- [ ] @replaceafill 