### PR TITLE
Small layout tweaks

### DIFF
--- a/chat/public/css/chat.css
+++ b/chat/public/css/chat.css
@@ -71,7 +71,7 @@ body.view-in-course .course-wrapper.chromeless {
 .chat-block .messages {
     padding: 30px 10px 60px 10px;
     box-sizing: border-box;
-    overflow: auto;
+    overflow-y: auto;
     flex-grow: 5000;
 }
 

--- a/chat/public/js/src/chat.js
+++ b/chat/public/js/src/chat.js
@@ -3,9 +3,6 @@
 function ChatTemplates(init_data) {
     "use strict";
 
-    // A spacer div at the bottom of the screen is required on the iOS app to account for the prev/next toolbar.
-    var SPACER_HEIGHT = 44;
-
     var h = virtualDom.h;
 
     var renderCollection = function(template, collection, ctx) {
@@ -80,7 +77,7 @@ function ChatTemplates(init_data) {
         var img_style = {};
         if (img_dims) {
             var win_width = $(window).width();
-            var win_height = $(window).height() - SPACER_HEIGHT;
+            var win_height = $(window).height() - ctx.spacer_height;
             img_style = optimalOverlayImageStyle(img_dims.width, img_dims.height, win_width, win_height);
         }
         return (
@@ -253,9 +250,9 @@ function ChatTemplates(init_data) {
         return h('div.actions', children);
     };
 
-    var spacerTemplate = function() {
+    var spacerTemplate = function(ctx) {
         return (
-            h('div.spacer', {style: {height: SPACER_HEIGHT + 'px'}})
+            h('div.spacer', {style: {height: ctx.spacer_height + 'px'}})
         );
     };
 
@@ -274,7 +271,7 @@ function ChatTemplates(init_data) {
             }
             children.push(actionsTemplate());
         }
-        children.push(spacerTemplate());
+        children.push(spacerTemplate(ctx));
         if (ctx.image_overlay) {
             children.push(imageOverlayTemplate(ctx));
         }
@@ -286,6 +283,10 @@ function ChatTemplates(init_data) {
 
 function ChatXBlock(runtime, element, init_data) {
     "use strict";
+
+    // A spacer div at the bottom of the screen is required on the iOS app to account for the prev/next toolbar.
+    // It's set to a value other than 0 in the init function if we detect we are on mobile.
+    var spacer_height = 0;
 
     var renderView = ChatTemplates(init_data);
 
@@ -373,6 +374,9 @@ function ChatXBlock(runtime, element, init_data) {
     var init = function() {
         // prevent rubber band effect (overscroll) in iOS app
         if ($('.course-wrapper.chromeless').length) {
+            // On iOS, some padding is required at the bottom of the screen.
+            spacer_height = 44;
+
             $('html, body').css({
                 position: 'fixed',
                 overflow: 'hidden'
@@ -870,7 +874,8 @@ function ChatXBlock(runtime, element, init_data) {
             show_buttons_leaving: state.show_buttons_leaving,
             image_overlay: state.image_overlay,
             image_dimensions: state.image_dimensions,
-            subject: state.subject
+            subject: state.subject,
+            spacer_height: spacer_height
         };
         return renderView(context);
     };


### PR DESCRIPTION
This patch includes two minor changes:

**1. Remove bottom spacer on desktop mode.**

The bottom spacer is needed on mobile, but on desktop it was just taking up space for no good reason. This patch makes it only use the spacer when in chromeless mode.

**2. Make message container scrollable in vertical direction only.**

On some browsers on Windows, the vertical scrollbar can consume horizontal space, causing useless horiziontal scrollbars to appear. Make the container only scrollable in the `y` direction to avoid this. We never expect the contents of the chat block to overflow in the horizontal direction.

**Testing**:

1. Add chat block to a course (default settings are fine).
2. On destkop, verify that the `.spacer` div has a height of zero.
3. If you can build the iOS mobile app: on mobile app, verify that the `.spacer` height is `44px`.
4. Verify that the message container is still scrollable and autoscrolls to the bottom when new messages come in.
5. If you have access to a Windows machine, verify that horizontal scrollbars don't appear when vertical scrollbars are visible.

**Reviewers**:

- [x] @bdero 