### PR TITLE
Use jQuery.Deferred rather than Promise for cross-browser compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,11 @@ Inside a fresh virtualenv, `cd` into the root folder of this repository
 (`xblock-chat`) and run
 
 ```bash
+$ pip install -U pip wheel
+$ pip install setuptools==24.3.1
 $ pip install -r requirements-test.txt
 $ pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt
 $ pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt
-$ pip install -r $VIRTUAL_ENV/src/xblock/requirements.txt
 ```
 
 You can then run the entire test suite via

--- a/chat/public/js/src/chat.js
+++ b/chat/public/js/src/chat.js
@@ -364,9 +364,9 @@ function ChatXBlock(runtime, element, init_data) {
      * pause: delays execution with a timeout
      */
     var pause = function(timeout) {
-        return new Promise(function(resolve, reject) {
-            setTimeout(resolve, timeout);
-        });
+        var promise = $.Deferred();
+        setTimeout(promise.resolve, timeout);
+        return promise;
     };
 
     /**
@@ -649,9 +649,8 @@ function ChatXBlock(runtime, element, init_data) {
         var promise;
         playSound(response_sound);
         playSoundInMutedLoop(bot_sound);
-        promise = new Promise(function(resolve, reject) {
-            resolve();
-        }).then(hideButtons)
+        promise = $.Deferred();
+        promise.then(hideButtons)
           .then(waitForButtonsHiding)
           .then(createUserMessage(event))
           .then(waitUserMessageAnimation)
@@ -659,6 +658,7 @@ function ChatXBlock(runtime, element, init_data) {
           .then(waitUserMessageAnimation)
           .then(saveState)
           .then(addNewBotMessages(state));
+        promise.resolve();
     };
 
     var showImageOverlay = function(event) {
@@ -843,9 +843,7 @@ function ChatXBlock(runtime, element, init_data) {
             return oldState;
         }
         if (step_messages.length) {
-            promise = new Promise(function(resolve, reject) {
-                resolve();
-            });
+            var promise = $.Deferred();
             step_messages.reduce(function(acc_promise, step_message, index, array) {
                 var message = step_message.message;
                 var bot_id = step_message.bot_id;
@@ -857,6 +855,7 @@ function ChatXBlock(runtime, element, init_data) {
                     .then(waitBotMessageAnimation)
                     .then(addBotMessageToHistory(oldState, is_last_message_in_step));
             }, promise);
+            promise.resolve();
         } else {
             showButtons(oldState);
         }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 Django>=1.8, <1.9
 -r requirements.txt
--e git+https://github.com/edx/xblock-sdk.git@8eb5f174dc59c0f4e40e10eaab56753958651d17#egg=xblock-sdk
+-e git+https://github.com/edx/xblock-sdk.git@c40b5dc3e9a2ded54119e922edf486d3ccec6c35#egg=xblock-sdk
 ddt
 selenium==2.47.3  # 2.48 is not working atm


### PR DESCRIPTION
This PR is to enable the Chat XBlock to work in Internet Explorer versions 10 and 11 - to fix this ticket: https://tasks.opencraft.com/browse/OC-2758

The incompatibility was caused by using JavaScript Promises which are not available in IE 11 and earlier. The solution is to use jQuery.Deferred instead. This was [already being used](https://github.com/open-craft/xblock-chat/blob/master/chat/public/js/src/chat.js#L433) in this XBlock so will not introduce problems.

*I have tested that this works with:*

* Standard Chrome browser
* Using IE11 on a Windows VM
* iOS simulator

*To Test*

* Use the Chat XBlock exactly as before - no behaviour has changed
* Verify that it continues to work on Firefox/Chrome etc.
* Verify that it can work on IE10 and IE11. This might require using browsertesting.com for example.

*Some notes*

* jQuery Deferred objects are not 100% equivalent to Promise objects prior to jQuery 1.9 - see https://thewayofcode.wordpress.com/tag/jquery-deferred-broken/ . However a newer version of jQuery is used.
* ~~One of the unit tests is failing, which I am investigating. That's why this is marked as 'WIP'~~ Fixed now!

*Screenshot of chat working under IE*

![virtualbox_windoze_01_07_2017_16_28_47 copy](https://user-images.githubusercontent.com/682175/27785633-24238f14-5fd6-11e7-8db8-68ac22cd1396.png)
