### PR TITLE
Remove flex display from main container and limit chat area height

### DIFF
--- a/chat/public/css/chat.css
+++ b/chat/public/css/chat.css
@@ -21,17 +21,25 @@ body.view-in-course .course-wrapper.chromeless {
     height: 100%;
     margin: 0;
     padding: 0;
-    display: flex;
-    flex-direction: column;
 }
 
 .course-wrapper.chromeless .chat-block {
     width: 100vw;
-    height: 100vh;
 }
 
 .chat-block .subject {
   width: 100%;
+}
+
+.chat-block .main-area {
+    /* Limit the height of the scrollable chat area to approximately
+       the window height minus standard LMS headers. */
+    max-height: calc(100vh - 350px);
+    overflow-y: auto;
+}
+.course-wrapper.chromeless .chat-block .main-area {
+    height: 100vh;
+    max-height: none;
 }
 
 .chat-block .subject p {
@@ -69,10 +77,8 @@ body.view-in-course .course-wrapper.chromeless {
 }
 
 .chat-block .messages {
-    padding: 30px 10px 60px 10px;
+    padding: 30px 10px;
     box-sizing: border-box;
-    overflow-y: auto;
-    flex-grow: 5000;
 }
 
 .chat-block .message {
@@ -158,7 +164,6 @@ body.view-in-course .course-wrapper.chromeless {
 .chat-block .buttons {
     box-sizing: border-box;
     display: block;
-    flex: 1 0 auto;
     max-height: 0%;
     overflow: hidden;
 }

--- a/chat/public/css/chat.css
+++ b/chat/public/css/chat.css
@@ -28,7 +28,7 @@ body.view-in-course .course-wrapper.chromeless {
 }
 
 .chat-block .subject {
-  width: 100%;
+    width: 100%;
 }
 
 .chat-block .main-area {
@@ -43,37 +43,37 @@ body.view-in-course .course-wrapper.chromeless {
 }
 
 .chat-block .subject p {
-  background-color: #fff;
-  color: #000;
-  padding: 10px 15px 20px 15px;
+    background-color: #fff;
+    color: #000;
+    padding: 10px 15px 20px 15px;
 }
 
 .chat-block .notice {
-  position: relative;
-  width: 100%;
-  margin: 15px auto;
+    position: relative;
+    width: 100%;
+    margin: 15px auto;
 }
 
 .chat-block .notice::before {
-  font-size: 25px;
-  font-family: FontAwesome;
-  position: absolute;
-  top: 50%;
-  transform: translate(0, -50%);
-  left: 10px;
+    font-size: 25px;
+    font-family: FontAwesome;
+    position: absolute;
+    top: 50%;
+    transform: translate(0, -50%);
+    left: 10px;
 }
 
 .chat-block .notice.correct::before {
-  content: "\f058";
+    content: "\f058";
 }
 
 .chat-block .notice.incorrect::before {
-  content: "\f057";
+    content: "\f057";
 }
 
 .chat-block .notice p {
-  padding: 20px 15px 20px 40px;
-  background: #f0f0f0;
+    padding: 20px 15px 20px 40px;
+    background: #f0f0f0;
 }
 
 .chat-block .messages {

--- a/chat/public/js/src/chat.js
+++ b/chat/public/js/src/chat.js
@@ -195,6 +195,10 @@ function ChatTemplates(init_data) {
             'data-message': JSON.stringify(item.message),
             'data-step_id': JSON.stringify(item.step)
         };
+        var button_props = {};
+        if (ctx.show_buttons_leaving) {
+            button_props.disabled = true;
+        }
         return (
             h(
                 'div.response-button',
@@ -204,6 +208,7 @@ function ChatTemplates(init_data) {
                 [
                     h(
                         'button',
+                        button_props,
                         item.message
                     )
                 ]
@@ -211,17 +216,18 @@ function ChatTemplates(init_data) {
         );
     };
 
-    var buttonsTemplate = function(ctx, extra_css_class, transition_duration) {
+    var buttonsTemplate = function(ctx) {
         var tag = 'div.buttons';
-        if (extra_css_class) {
-            tag = tag.concat('.' + extra_css_class);
+        if (ctx.show_buttons_entering) {
+            tag += '.entering';
+        } else if (ctx.show_buttons_leaving) {
+            tag += '.leaving';
         }
         var attributes = {};
-        if (transition_duration) {
-            attributes = {
-                style: {
-                    transition: 'max-height '+ transition_duration + 'ms linear'
-                }
+        if (ctx.show_buttons_entering || ctx.show_buttons_leaving) {
+            var transition_duration = init_data["buttons_entering_transition_duration"];
+            attributes.style = {
+                transition: 'max-height '+ transition_duration + 'ms linear'
             };
         }
         var step = ctx.current_step && init_data["steps"][ctx.current_step];
@@ -261,16 +267,7 @@ function ChatTemplates(init_data) {
             messagesTemplate(ctx)
         ];
         if (ctx.show_buttons) {
-            var extra_class = null;
-            var transition_duration = init_data["buttons_entering_transition_duration"];
-            if (ctx.show_buttons_entering) {
-                extra_class = 'entering';
-            } else if (ctx.show_buttons_leaving) {
-                extra_class = 'leaving';
-            } else {
-                transition_duration = null;
-            }
-            main_area_content.push(buttonsTemplate(ctx, extra_class, transition_duration));
+            main_area_content.push(buttonsTemplate(ctx));
         }
         var children = [
             subjectTemplate(ctx),

--- a/chat/public/js/src/chat.js
+++ b/chat/public/js/src/chat.js
@@ -25,18 +25,18 @@ function ChatTemplates(init_data) {
       var tag = 'div.notice';
 
       if (step.notice_type) {
-        tag = tag.concat('.' + step.notice_type);
+          tag = tag.concat('.' + step.notice_type);
       }
 
       return h(tag, h('p', step.notice_text));
     };
 
     var subjectTemplate = function(ctx) {
-      if (ctx.subject) {
-        return h('div.subject', h('p', ctx.subject));
-      } else {
-        return null;
-      }
+        if (ctx.subject) {
+            return h('div.subject', h('p', ctx.subject));
+        } else {
+            return null;
+        }
     };
 
     // Position the image to make it cover the max possible area of the window while
@@ -126,13 +126,13 @@ function ChatTemplates(init_data) {
             tag = tag.concat('.' + extra_css_class);
         }
         var messageContent = botMessageContentTemplate(
-          message.from, tag, children
+            message.from, tag, children
         );
 
         if (step && step.notice_text) {
-          return [noticeTemplate(step), messageContent];
+            return [noticeTemplate(step), messageContent];
         } else {
-          return messageContent;
+            return messageContent;
         }
     };
 

--- a/chat/public/js/src/chat.js
+++ b/chat/public/js/src/chat.js
@@ -257,21 +257,27 @@ function ChatTemplates(init_data) {
     };
 
     var mainTemplate = function(ctx) {
-        var children = [
-            subjectTemplate(ctx),
+        var main_area_content = [
             messagesTemplate(ctx)
         ];
         if (ctx.show_buttons) {
+            var extra_class = null;
+            var transition_duration = init_data["buttons_entering_transition_duration"];
             if (ctx.show_buttons_entering) {
-                children.push(buttonsTemplate(ctx, 'entering', init_data["buttons_entering_transition_duration"]));
+                extra_class = 'entering';
             } else if (ctx.show_buttons_leaving) {
-                children.push(buttonsTemplate(ctx, 'leaving', init_data["buttons_leaving_transition_duration"]));
+                extra_class = 'leaving';
             } else {
-                children.push(buttonsTemplate(ctx));
+                transition_duration = null;
             }
-            children.push(actionsTemplate());
+            main_area_content.push(buttonsTemplate(ctx, extra_class, transition_duration));
         }
-        children.push(spacerTemplate(ctx));
+        var children = [
+            subjectTemplate(ctx),
+            h('div.main-area', main_area_content),
+            actionsTemplate(),
+            spacerTemplate(ctx)
+        ];
         if (ctx.image_overlay) {
             children.push(imageOverlayTemplate(ctx));
         }
@@ -690,12 +696,13 @@ function ChatXBlock(runtime, element, init_data) {
      * if there are response buttons and the bot sound wasn't the last played
      */
     var animate = function(state) {
-        var $messages = $root.find('.messages');
+        var $container = $root.find('.main-area');
+        var scroll_top = $container.prop('scrollHeight');
         if (!state.scroll_delay) {
-            $messages.scrollTop($messages.prop("scrollHeight"));
+            $container.scrollTop(scroll_top);
         } else if (state.bot_spinner || (state.show_buttons && !state.show_buttons_leaving) || state.new_user_message) {
-            $messages.animate(
-                {scrollTop: $messages.prop("scrollHeight")},
+            $container.animate(
+                {scrollTop: scroll_top},
                 {duration: state.scroll_delay, queue: false});
         }
         if (last_sound_played != bot_sound && $root.find('.bot.fadein-message').length) {

--- a/chat/public/js/src/chat.js
+++ b/chat/public/js/src/chat.js
@@ -407,10 +407,10 @@ function ChatXBlock(runtime, element, init_data) {
         state.scroll_delay = 0;
         state.image_overlay = null;
         state.image_dimensions = {};
+        state.subject = init_data["subject"];
         preloadImages();
         applyState(state);
         state.scroll_delay = init_data["scroll_delay"];
-        state.subject = init_data["subject"];
         return state;
     };
 

--- a/tests/integration/test_chat.py
+++ b/tests/integration/test_chat.py
@@ -381,6 +381,19 @@ class TestChat(StudioEditableBaseTest):
         ]
         self.assertEqual(button_labels, default_response_labels)
 
+    # Make button leave animation long enough for Selenium to be able to inspect the leaving buttons.
+    @patch('chat.chat.BUTTONS_LEAVING_TRANSITION_DURATION', 5000)
+    def test_button_disabled_after_click(self):
+        self.load_scenario('xml/chat_defaults.xml')
+        self.wait_until_buttons_are_displayed()
+        buttons = self.element.find_elements_by_css_selector('.buttons .response-button button')
+        self.assertEqual(len(buttons), 2)
+        for button in buttons:
+            self.assertFalse(button.get_attribute('disabled'))
+        buttons[0].click()
+        for button in buttons:
+            self.assertTrue(button.get_attribute('disabled'))
+
     def configure_block(
             self, yaml, expect_success=True, bot_image_url=None, avatar_border_color=None,
             enable_restart_button=None, subject=None


### PR DESCRIPTION
This patch removes `flex` rules from the chat block div. The flex rules were causing scrolling issues in Safari. Things are simpler without flex.

This also limits the height of the block. The benefit of that is that users don't have to scroll the screen down every time they click a response button.

This PR also contains minor code cleanup and a bugfix where double clicking a response button could put the block into corrupt state.

**Testing**:

1. Add chat block to a unit.
1. Resize your browser window to make the height of the screen small.
1. Verify that there is a max height limit on the chat block. It may not exactly match the available space, but the height should be reasonably limited.
1. Interact with the bot and verify that (auto)scrolling of messages and buttons works correctly, including in Safari.

**Author notes and concerns**:

The new layout was tested in the iOS app. The layout works correctly if the 'subject' is not set/empty. If the subject is set, the height is not limited properly. Limiting the height correctly with the subject present is trickier because we don't know the height of the subject in advance. I wasn't able to look into that in detail due to time constraints, but in the future, we will probably have to fix that. Currently it shouldn't be a problem for existing users because the subject feature is new and nobody is using it in production yet.

**Reviewers**:

- [x] @bdero 