### PR TITLE
Add user id to localStorage key.

### DIFF
--- a/chat/chat.py
+++ b/chat/chat.py
@@ -230,6 +230,7 @@ class ChatXBlock(StudioEditableXBlockMixin, XBlock):
             "response_sound_url": self.runtime.handler_url(
                 self, 'serve_audio', 'response.wav'),
             "user_id": USER_ID,
+            "anonymous_student_id": self._get_student_id(),
             "steps": steps,
             "first_step": first_step,
             "user_state": self._get_user_state(),
@@ -277,6 +278,13 @@ class ChatXBlock(StudioEditableXBlockMixin, XBlock):
         current_user = User.objects.get(username=username)  # pylint: disable=no-member
         urls = get_profile_image_urls_for_user(current_user)
         return urls.get('large')
+
+    def _get_student_id(self):
+        """Get student anonymous ID or normal ID"""
+        if hasattr(self.runtime, 'anonymous_student_id'):
+            return self.runtime.anonymous_student_id
+        else:
+            return self.scope_ids.user_id
 
     def _get_block_id(self):
         """

--- a/chat/public/js/src/chat.js
+++ b/chat/public/js/src/chat.js
@@ -312,7 +312,9 @@ function ChatXBlock(runtime, element, init_data) {
      * is stored in localStorage.
      */
     var localStorageKey = function() {
-        return 'chat-xblock-' + init_data["block_id"];
+        var user_id = init_data["anonymous_student_id"];
+        var block_id = init_data["block_id"];
+        return 'chat-xblock/' +  user_id + '/' + block_id;
     };
 
     /**


### PR DESCRIPTION
This makes it possible for multiple users to use the same browser without seeing the results of the previous user.

**Note**: We did not try to maintain backwards compatibility. After this change is deployed, any existing chat block entries in `localStorage` will be ignored. This is not considered to be much of a problem because `localStorage` is secondary (fallback) storage so that the block works offline, but the data is also stored in the main database.

**Testing**:

1. Add a chat block to a course. 
1. Log into the LMS as user A, go to the chat block, and interact with the chat.
1. Reload the page and observe that the state is persisted.
1. Log out.
1. Log into the LMS again, this time as user B.
1. Go to the chat block and verify that the block loads in fresh state and previous state from user B is not visible.

I suggest using standard `staff` and `honor` users.

**Reviewers**:

- [x] @haikuginger 