### PR TITLE
Fix avatar/message alignment when message is long.

### DIFF
--- a/chat/public/css/chat.css
+++ b/chat/public/css/chat.css
@@ -103,26 +103,40 @@ body.view-in-course .course-wrapper.chromeless {
 
 .chat-block .avatar {
     height: 45px;
-    min-width: 45px;
+    width: 45px;
     display: inline-block;
+    position: relative;
     vertical-align: bottom;
 }
 
 .chat-block .avatar img {
     box-sizing: border-box;
     display: block;
-    height: 100%;
-    width: auto;
+    max-height: 100%;
+    max-width: 100%;
     border-width: 2px;
     border-style: solid;
     border-color: #39b549;
     border-radius: 50%;
+    position: absolute;
+    bottom: 0;
+}
+
+.chat-block .bot .avatar img {
+    left: 0;
+}
+
+.chat-block .user .avatar img {
+    right: 0;
 }
 
 .chat-block .message-body {
     position: relative;
     display: inline-block;
     vertical-align: middle;
+    /* Chat message can take the available width, reduced by the width of the avatar (45px)
+       and the margin between the avatar and the message (25px). */
+    max-width: calc(100% - 45px - 25px);
 }
 
 .chat-block .message-body p {


### PR DESCRIPTION
When the message was long, the box with the message would be pushed down below the avatar.

This patch fixes the problem by limiting the available width of both the avatar and the message box.

This means that landscape avatar images will now be limited to a width of 45px, but that is probably preferred anyway. Image aspect ratio will still be preserved.

**Screenshot before**:

![screen shot 2017-11-24 at 09 07 09](https://user-images.githubusercontent.com/32585/33200967-fe816668-d0f6-11e7-9da9-7074021bb8f6.png)

**Screenshots after**:

Standard (square) avatars:

![screen shot 2017-11-24 at 08 47 25](https://user-images.githubusercontent.com/32585/33200988-1033b4c4-d0f7-11e7-8ea5-c76ff22a21fa.png)

With portrait avatars:

![screen shot 2017-11-24 at 08 49 58](https://user-images.githubusercontent.com/32585/33201021-260c8f0a-d0f7-11e7-8586-1111809e000a.png)

With landscape avatars:

![screen shot 2017-11-24 at 08 51 04](https://user-images.githubusercontent.com/32585/33201036-32c008d0-d0f7-11e7-8d0b-14f09196edba.png)

**Testing instructions**:

1. Install xblock-chat & add it to a course.
2. Modify the default text message to make them longer.
3. Use the responsive xblock view to verify that the message layout does not break on small screens (responsive xblock URLs look like `http://localhost:8000/xblock/<block-id>` where you can get the `<block-id>` using the "staff debug" tool in the LMS).