### PR TITLE
Fix multiple clicks on responses result in inconsistent state

### DIFF
--- a/chat/public/css/chat.css
+++ b/chat/public/css/chat.css
@@ -223,6 +223,10 @@ body.view-in-course .course-wrapper.chromeless {
     width: 80%;
 }
 
+.chat-block .response-button button:disabled {
+    opacity: 1;
+}
+
 .chat-block .response-button button,
 .chat-block .response-button button:hover,
 .chat-block .response-button button:active,
@@ -236,6 +240,10 @@ body.view-in-course .course-wrapper.chromeless {
     text-shadow: none;
     outline: 0;
     border-radius: 10px;
+}
+
+.chat-block .response-button.selected button {
+    opacity: 0.5;
 }
 
 .chat-block .actions {


### PR DESCRIPTION
It was possible to click on multiple responses in a chat session, leaving it in an inconsistent state. Additionally clicking on a response results in all response buttons having disabled appearance, making it hard to distinguish which response was selected.