### PR TITLE
Use yaml.safe_load instead of yaml.load 

### DIFF
--- a/chat/chat.py
+++ b/chat/chat.py
@@ -183,7 +183,7 @@ class ChatXBlock(StudioEditableXBlockMixin, XBlock):
     def _decode_steps_string(steps):
         """Loads the string containing the list of steps."""
         try:
-            steps = yaml.load(steps)
+            steps = yaml.safe_load(steps)
         except yaml.parser.ParserError:
             steps = None
         if isinstance(steps, list):
@@ -256,7 +256,7 @@ class ChatXBlock(StudioEditableXBlockMixin, XBlock):
         If the value is a string, it assumes it represents the image url of the default bot."""
         mapping = {DEFAULT_BOT_ID: self._default_bot_image_url()}
 
-        image_urls = yaml.load(self.bot_image_url)
+        image_urls = yaml.safe_load(self.bot_image_url)
         if isinstance(image_urls, dict):
             for bot_id in image_urls:
                 key = self._custom_bot_id(bot_id)


### PR DESCRIPTION
Changed uses of ``yaml.load`` to ``yaml.safe_load``. Using ``safe_load`` here has no disadvantage since dumping and loading arbitrary Python objects is not required. 

YAML documents can include executable code and objects which that be executed during the loading process. As such it is [not safe](https://pyyaml.org/wiki/PyYAMLDocumentation#loading-yaml) to use ``yaml.load`` with user-provided code. 

While the YAML code provided by users in this case might not exactly be untrusted, a user might be tempted to copy paste YAML code from an untrusted source because it claims to do what they want. 

**JIRA tickets**: None

**Discussions**: Suggested in discussion of OC-3417 and got go-ahead from reviewer.

**Merge deadline**: None

**Testing instructions**:
1. Setup test environment as required by the [Read Me](https://github.com/open-craft/xblock-chat/blob/52f793e6d55beba9cdb333daf5eb94a8e5838b18/README.md)
2. Run: ``python run_tests.py tests.integration.test_chat:TestChat.test_yaml_script`` or any other test involving loading YAML.

**Reviewers**
- [ ] @mtyaka 