### PR TITLE
Fix layout issues in Chromeless view on iOS app.

### DIFF
--- a/chat/public/css/chat.css
+++ b/chat/public/css/chat.css
@@ -25,6 +25,7 @@ body.view-in-course .course-wrapper.chromeless {
 
 .course-wrapper.chromeless .chat-block {
     width: 100vw;
+    height: 100vh;
     display: block;
     overflow: auto;
 }
@@ -47,7 +48,7 @@ body.view-in-course .course-wrapper.chromeless {
     overflow-y: auto;
 }
 .course-wrapper.chromeless .chat-block .main-area {
-    max-height: 95vh;
+    max-height: calc(100vh - 50px);  /* keep 50px for the actions div */
 }
 
 .chat-block .subject p {

--- a/chat/public/js/src/chat.js
+++ b/chat/public/js/src/chat.js
@@ -77,7 +77,7 @@ function ChatTemplates(init_data) {
         var img_style = {};
         if (img_dims) {
             var win_width = $(window).width();
-            var win_height = $(window).height() - ctx.spacer_height;
+            var win_height = $(window).height();
             img_style = optimalOverlayImageStyle(img_dims.width, img_dims.height, win_width, win_height);
         }
         return (
@@ -261,12 +261,6 @@ function ChatTemplates(init_data) {
         return h('div.actions', children);
     };
 
-    var spacerTemplate = function(ctx) {
-        return (
-            h('div.spacer', {style: {height: ctx.spacer_height + 'px'}})
-        );
-    };
-
     var mainAreaTemplate = function(ctx) {
         var main_area_content = [
             messagesTemplate(ctx)
@@ -286,8 +280,7 @@ function ChatTemplates(init_data) {
     var mainTemplate = function(ctx) {
         var children = [
             mainAreaTemplate(ctx),
-            actionsTemplate(),
-            spacerTemplate(ctx)
+            actionsTemplate()
         ];
         if (ctx.image_overlay) {
             children.push(imageOverlayTemplate(ctx));
@@ -303,10 +296,6 @@ function ChatTemplates(init_data) {
 
 function ChatXBlock(runtime, element, init_data) {
     "use strict";
-
-    // A spacer div at the bottom of the screen is required on the iOS app to account for the prev/next toolbar.
-    // It's set to a value other than 0 in the init function if we detect we are on mobile.
-    var spacer_height = 0;
 
     var renderView = ChatTemplates(init_data);
 
@@ -394,16 +383,6 @@ function ChatXBlock(runtime, element, init_data) {
      * user data passed from the backend
      */
     var init = function() {
-        // prevent rubber band effect (overscroll) in iOS app
-        if ($('.course-wrapper.chromeless').length) {
-            // On iOS, some padding is required at the bottom of the screen.
-            spacer_height = 44;
-
-            $('html, body').css({
-                position: 'fixed',
-                overflow: 'hidden'
-            });
-        }
         $element.on('click', '.response-button', submitResponse);
         $element.on('click', '.restart-button', restartChat);
         $element.on('click', '.message-body img', showImageOverlay);
@@ -930,8 +909,7 @@ function ChatXBlock(runtime, element, init_data) {
             selected_button: state.selected_button,
             image_overlay: state.image_overlay,
             image_dimensions: state.image_dimensions,
-            subject: state.subject,
-            spacer_height: spacer_height
+            subject: state.subject
         };
         return renderView(context);
     };


### PR DESCRIPTION
**Description**:

- The spacer div is no longer necessary and is actually interferring
  with the layout, so remove it.
- Fix the height of the chat block div to 100vh.
- Make the height of the scrollable div with messages no higher than
  100vh - 50px (with 50px reserved for the actions div with the reset
  button).
- Remove the overscroll (rubber band) fix, which was no longer working
  and was causing weird effects when scrolling.

**Testing instructions**:

1. Add the chat XBlock to a devstack instance.
1. Add a chat XBlock to the demo course.
1. Build a version of the edX iOS app with private.yaml modified to point to your devstack instance: add an OAuth2 client in the devstack Django admin and put its ID in the OAUTH_CLIENT_ID field, and modify API_HOST_URL to point to the devstack instance.
1. Start the app in the iOS simulator, navigate to the course, and try the chat. The restart button should remain visible, and you should always be able to see the last lines of the chat.

**Reviewers**:
- [ ] @ciuin