### PR TITLE
Migrate to CircleCI v2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,20 +1,45 @@
-machine:
-  python:
-    version: 2.7.10
-dependencies:
-  override:
-    - "pip install -U pip wheel"
-    # Temporarily pin setuptools to a specific version.
-    # See commit message of https://github.com/open-craft/problem-builder/commit/51277a34fb426724616618c1afdb893ab2de4c6b for more info:
-    - "pip install setuptools==24.3.1"
-    - "pip install -r requirements.txt"
-    - "pip install -r requirements-test.txt"
-    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
-    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
-    - "pip install -e ."
-    - "mkdir var"
-test:
-  override:
-    - "pep8 chat --max-line-length=120"
-    - "pylint chat --disable=all --enable=function-redefined,undefined-variable,unused-import,unused-variable"
-    - "python run_tests.py"
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:2.7.14
+    parallelism: 2
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependencies-{{ checksum "circle.yml" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-test.txt" }}
+      - run:
+          name: Install Python deps in a venv
+          command: |
+            virtualenv venv
+            . venv/bin/activate
+            pip install -U pip wheel
+            # Temporarily pin setuptools to a specific version.
+            # See commit message of https://github.com/open-craft/problem-builder/commit/51277a34fb426724616618c1afdb893ab2de4c6b for more info:
+            pip install setuptools==24.3.1
+            pip install -r requirements.txt
+            pip install -r requirements-test.txt
+            pip install -r venv/src/xblock-sdk/requirements/base.txt
+            pip install -r venv/src/xblock-sdk/requirements/test.txt
+            pip install -e .
+            mkdir var
+      - save_cache:
+          key: dependencies-{{ checksum "circle.yml" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-test.txt" }}
+          paths:
+            - "venv"
+      - run:
+          name: Install firefox 38.0.5
+          command: |
+            FIREFOX_URL="https://sourceforge.net/projects/ubuntuzilla/files/mozilla/apt/pool/main/f/firefox-mozilla-build/firefox-mozilla-build_38.0.5-0ubuntu1_amd64.deb/download" \
+            && curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.deb $FIREFOX_URL \
+            && sudo dpkg -i /tmp/firefox.deb || sudo apt-get -f install  \
+            && sudo apt-get install -y libgtk3.0-cil-dev libasound2 libasound2 libdbus-glib-1-2 libdbus-1-3 libgtk2.0-0 \
+            && rm -rf /tmp/firefox.deb \
+            && firefox --version
+      - run:
+          name: Run tests
+          command: |
+            . venv/bin/activate
+            if [ $CIRCLE_NODE_INDEX = '0' ]; then pep8 chat --max-line-length=120; fi
+            if [ $CIRCLE_NODE_INDEX = '1' ]; then pylint chat --disable=all --enable=function-redefined,undefined-variable,unused-import,unused-variable; fi
+            xvfb-run --server-args="-screen 0 1280x1024x24" python run_tests.py


### PR DESCRIPTION
Migrating to CircleCI version 2.

JIRA Ticket: OC-4151

Testing instructions:

Check that tests are passing.

Note to reviewer:

Added parallelism on tests.
Added Cache, so that it doesn't have to install requirements each time.
Installs firefox 38.0.5, which is needed to run tests.

Reviewers:

[Sven]