### PR TITLE
BB-311 Fix xblock-chat CI error

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ jobs:
           command: |
             FIREFOX_URL="https://sourceforge.net/projects/ubuntuzilla/files/mozilla/apt/pool/main/f/firefox-mozilla-build/firefox-mozilla-build_38.0.5-0ubuntu1_amd64.deb/download" \
             && curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.deb $FIREFOX_URL \
+            && sudo apt-get update \
             && sudo dpkg -i /tmp/firefox.deb || sudo apt-get -f install  \
             && sudo apt-get install -y libgtk3.0-cil-dev libasound2 libasound2 libdbus-glib-1-2 libdbus-1-3 libgtk2.0-0 \
             && rm -rf /tmp/firefox.deb \


### PR DESCRIPTION
Originally CircleCi would fail trying to install libxcursor1_1.1.14-1+deb8u1_amd64.deb, while installing firefox and dependencies. This happened because this release was updated to libxcursor1_1.1.14-1+deb8u2_amd64.deb on 2018-08-18 (see: http://security.debian.org/pool/updates/main/libx/libxcursor/)

Adding an apt-get update makes the CircleCi VM aware of this change and it installs without problems, see the CircleCi report for this commit.